### PR TITLE
chore: bump version to 0.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ctrf-cli",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ctrf-cli",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "ctrf": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "ctrf-cli",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Various CTRF utilities available from the command line",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Bump version to 0.0.6 to retry the npm publish that was failing for v0.0.5.

v0.0.5-next-1 published successfully with the same configuration, so trying a new version number to work around potential npm caching issues.