### PR TITLE
docs: update version references to 0.0.5-next-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ By standardizing test results, reports can be validated, merged, compared, and a
 Use `npx` to run the CLI without installing:
 
 ```bash
-npx ctrf-cli@0.0.5 validate report.json
+npx ctrf-cli@0.0.5-next-2 validate report.json
 ```
 
 ### Global Installation
@@ -32,7 +32,7 @@ npx ctrf-cli@0.0.5 validate report.json
 Or install globally for repeated use:
 
 ```bash [npm]
-npm install -g ctrf-cli@0.0.5
+npm install -g ctrf-cli@0.0.5-next-2
 ```
 
 After global installation, use the `ctrf` command:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ By standardizing test results, reports can be validated, merged, compared, and a
 Use `npx` to run the CLI without installing:
 
 ```bash
-npx ctrf-cli@0.0.5-next-2 validate report.json
+npx ctrf-cli@0.0.5-next-1 validate report.json
 ```
 
 ### Global Installation
@@ -32,7 +32,7 @@ npx ctrf-cli@0.0.5-next-2 validate report.json
 Or install globally for repeated use:
 
 ```bash [npm]
-npm install -g ctrf-cli@0.0.5-next-2
+npm install -g ctrf-cli@0.0.5-next-1
 ```
 
 After global installation, use the `ctrf` command:


### PR DESCRIPTION
Update version references in README from 0.0.5 to 0.0.5-next-2 to reflect the next prerelease version.

This ensures users trying the npx and global install examples will use the upcoming prerelease version.