### PR TITLE
chore(deps): upgrade ctrf to ^0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
-        "ctrf": "^0.1.0",
+        "ctrf": "^0.2.0",
         "glob": "^13.0.1",
         "typescript": "^5.4.5",
         "yargs": "^17.7.2"
@@ -1724,15 +1724,14 @@
       }
     },
     "node_modules/ctrf": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ctrf/-/ctrf-0.1.0.tgz",
-      "integrity": "sha512-SQzXW/ENpEhKesO7sk9sknfm4qu2vbCRvQVGaUf9cm/Awb6QBTeMYmuhiAKWLk9YIj9uLJhvmEcn9m9qRp74HQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ctrf/-/ctrf-0.2.0.tgz",
+      "integrity": "sha512-3tm25Qj6U4Ih10p+rXbobGmQ8udNVGfNnuQ9/L648t5641LkuHcDU6ZTnwClJujhd14xvWc6LPWc57aiYau0tA==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "glob": "^13.0.0",
-        "typescript": "^5.8.3",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -3048,6 +3047,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test-results"
   ],
   "dependencies": {
-    "ctrf": "^0.1.0",
+    "ctrf": "^0.2.0",
     "glob": "^13.0.1",
     "typescript": "^5.4.5",
     "yargs": "^17.7.2"


### PR DESCRIPTION
## Summary

Upgrades the `ctrf` dependency from `^0.1.0` to `^0.2.0`.

## Breaking changes

None. The `0.2.0` release contains infrastructure changes only:

- Added CJS dual export via tsup (ESM + CJS support)
- Removed `typescript` from runtime dependencies
- Dependency bumps (ajv, eslint, vitest, prettier)

All API exports used by ctrf-cli are unchanged.

## Verification

- ✅ Build passes (zero TypeScript errors)
- ✅ All 70 tests pass