### PR TITLE
Add Node 26 to CI matrix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '26'
           cache: npm
 
       - name: Install
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['20', '22', '24']
+        node: ['20', '22', '24', '26']
 
     permissions:
       contents: read
@@ -119,7 +119,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '26'
           cache: npm
 
       - name: Install


### PR DESCRIPTION
## Summary
- add Node 26 to the test/build matrix
- move quality and security jobs from Node 22 to Node 26
- keep the existing standard CI structure

## Verification
- ruby -e "require 'yaml'; Dir['.github/workflows/*.{yml,yaml}'].each { |f| YAML.load_file(f); puts f }"
- source ~/.nvm/nvm.sh && nvm use 24.2.0 && npm run all
- source ~/.nvm/nvm.sh && nvm use 24.2.0 && npm audit --omit=dev